### PR TITLE
最後に猫の鳴き声をつけるechoコマンド

### DIFF
--- a/catecho/Cargo.toml
+++ b/catecho/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+clap = "4"

--- a/catecho/Cargo.toml
+++ b/catecho/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "catecho"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/catecho/Cargo.toml
+++ b/catecho/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2021"
 
 [dependencies]
 clap = "4"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "2"

--- a/catecho/Cargo.toml
+++ b/catecho/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = "4"
+clap = {version = "4", features = ["derive"]}
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/catecho/src/main.rs
+++ b/catecho/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/catecho/src/main.rs
+++ b/catecho/src/main.rs
@@ -5,10 +5,11 @@ use clap::Parser;
 #[command(version, about = "An echo-like command adds cat meows")]
 struct Args {
     #[arg(required = true, help = "Input text")]
-    text: String,
+    text: Vec<String>,
 }
 
 fn main() {
     let args = Args::parse();
-    println!("{}", args.text);
+    let text = args.text;
+    println!("{}{}", text.join(" "), " MEOW");
 }

--- a/catecho/src/main.rs
+++ b/catecho/src/main.rs
@@ -1,3 +1,14 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author = "Vermee81")]
+#[command(version, about = "An echo-like command adds cat meows")]
+struct Args {
+    #[arg(required = true, help = "Input text")]
+    text: String,
+}
+
 fn main() {
-    println!("Hello, world!");
+    let args = Args::parse();
+    println!("{:#?}", args);
 }

--- a/catecho/src/main.rs
+++ b/catecho/src/main.rs
@@ -10,5 +10,5 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-    println!("{:#?}", args);
+    println!("{}", args.text);
 }

--- a/catecho/src/main.rs
+++ b/catecho/src/main.rs
@@ -6,10 +6,13 @@ use clap::Parser;
 struct Args {
     #[arg(required = true, help = "Input text")]
     text: Vec<String>,
+    #[arg(short = 'n', help = "Do not print newline")]
+    no_newline: bool,
 }
 
 fn main() {
     let args = Args::parse();
     let text = args.text;
-    println!("{}{}", text.join(" "), " MEOW");
+    let no_newline = args.no_newline;
+    print!("{}{}{}", text.join(" ")," MEOW",if no_newline {""} else {"\n"} );
 }

--- a/catecho/tests/cli.rs
+++ b/catecho/tests/cli.rs
@@ -1,6 +1,13 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 
+// 引数に文字列を指定して実行して、その文字列が標準出力に出力されることを確認
+#[test]
+fn runs() {
+    let mut cmd: Command = Command::cargo_bin("catecho").unwrap();
+    cmd.arg("Hello").assert().success().stdout("Hello\n");
+}
+
 // 引数なしで実行してUSAGEが標準エラーに出力されることを確認
 #[test]
 fn dies_no_args() {

--- a/catecho/tests/cli.rs
+++ b/catecho/tests/cli.rs
@@ -3,13 +3,6 @@ use predicates::prelude::*;
 
 const BIN_NAME: &str = "catecho";
 
-// 引数に文字列を指定して実行して、その文字列が標準出力に出力されることを確認
-#[test]
-fn runs() {
-    let mut cmd: Command = Command::cargo_bin(BIN_NAME).unwrap();
-    cmd.arg("Hello").assert().success().stdout("Hello MEOW\n");
-}
-
 // 文字が2つ以上ある場合に、それらが連結されて標準出力に出力されることを確認
 #[test]
 fn runs_multiple() {

--- a/catecho/tests/cli.rs
+++ b/catecho/tests/cli.rs
@@ -15,6 +15,13 @@ fn runs_multiple() {
     cmd.arg("Hello").arg("World").assert().success().stdout("Hello World MEOW\n");
 }
 
+// -nオプションを指定して実行して、改行がないことを確認
+#[test]
+fn runs_no_newline() {
+    let mut cmd: Command = Command::cargo_bin("catecho").unwrap();
+    cmd.arg("-n").arg("Hello").arg("World").assert().success().stdout("Hello World MEOW");
+}
+
 // 引数なしで実行してUSAGEが標準エラーに出力されることを確認
 #[test]
 fn dies_no_args() {

--- a/catecho/tests/cli.rs
+++ b/catecho/tests/cli.rs
@@ -8,6 +8,13 @@ fn runs() {
     cmd.arg("Hello").assert().success().stdout("Hello MEOW\n");
 }
 
+// 文字が2つ以上ある場合に、それらが連結されて標準出力に出力されることを確認
+#[test]
+fn runs_multiple() {
+    let mut cmd: Command = Command::cargo_bin("catecho").unwrap();
+    cmd.arg("Hello").arg("World").assert().success().stdout("Hello World MEOW\n");
+}
+
 // 引数なしで実行してUSAGEが標準エラーに出力されることを確認
 #[test]
 fn dies_no_args() {

--- a/catecho/tests/cli.rs
+++ b/catecho/tests/cli.rs
@@ -1,30 +1,32 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 
+const BIN_NAME: &str = "catecho";
+
 // 引数に文字列を指定して実行して、その文字列が標準出力に出力されることを確認
 #[test]
 fn runs() {
-    let mut cmd: Command = Command::cargo_bin("catecho").unwrap();
+    let mut cmd: Command = Command::cargo_bin(BIN_NAME).unwrap();
     cmd.arg("Hello").assert().success().stdout("Hello MEOW\n");
 }
 
 // 文字が2つ以上ある場合に、それらが連結されて標準出力に出力されることを確認
 #[test]
 fn runs_multiple() {
-    let mut cmd: Command = Command::cargo_bin("catecho").unwrap();
+    let mut cmd: Command = Command::cargo_bin(BIN_NAME).unwrap();
     cmd.arg("Hello").arg("World").assert().success().stdout("Hello World MEOW\n");
 }
 
 // -nオプションを指定して実行して、改行がないことを確認
 #[test]
 fn runs_no_newline() {
-    let mut cmd: Command = Command::cargo_bin("catecho").unwrap();
+    let mut cmd: Command = Command::cargo_bin(BIN_NAME).unwrap();
     cmd.arg("-n").arg("Hello").arg("World").assert().success().stdout("Hello World MEOW");
 }
 
 // 引数なしで実行してUSAGEが標準エラーに出力されることを確認
 #[test]
 fn dies_no_args() {
-    let mut cmd = Command::cargo_bin("catecho").unwrap();
+    let mut cmd = Command::cargo_bin(BIN_NAME).unwrap();
     cmd.assert().failure().stderr(predicate::str::contains("Usage"));
 }

--- a/catecho/tests/cli.rs
+++ b/catecho/tests/cli.rs
@@ -5,7 +5,7 @@ use predicates::prelude::*;
 #[test]
 fn runs() {
     let mut cmd: Command = Command::cargo_bin("catecho").unwrap();
-    cmd.arg("Hello").assert().success().stdout("Hello\n");
+    cmd.arg("Hello").assert().success().stdout("Hello MEOW\n");
 }
 
 // 引数なしで実行してUSAGEが標準エラーに出力されることを確認

--- a/catecho/tests/cli.rs
+++ b/catecho/tests/cli.rs
@@ -1,0 +1,9 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+// 引数なしで実行してUSAGEが標準エラーに出力されることを確認
+#[test]
+fn dies_no_args() {
+    let mut cmd = Command::cargo_bin("catecho").unwrap();
+    cmd.assert().failure().stderr(predicate::str::contains("Usage"));
+}


### PR DESCRIPTION
catecho Hello World と実行したら、"Hello World MEOW\n"と猫の鳴き声をつけて標準出力に返すコマンドを追加する。

-n オプションをつけると改行がなくなる。
"catecho -n Hello World" と実行したら、"Hello World MEOW" となる。